### PR TITLE
Integration test with dockerized local sfn

### DIFF
--- a/src/stepwise/client.clj
+++ b/src/stepwise/client.clj
@@ -25,7 +25,7 @@
 
 (defn endpoint-config []
   ;; TODO the endpoint should be set in env var
-  (AwsClientBuilder$EndpointConfiguration. "http://localdocker:8083" "us-east-1"))
+  (AwsClientBuilder$EndpointConfiguration. "http://sfn:8083" "us-east-1"))
 
 (defn localhost-client []
   (-> (AWSStepFunctionsClientBuilder/standard)

--- a/src/stepwise/client.clj
+++ b/src/stepwise/client.clj
@@ -17,15 +17,26 @@
     (.setSocketTimeout 70000)
     (.setMaxConnections 75)))
 
+(def stock-default-client
+  (delay (-> (AWSStepFunctionsClientBuilder/standard)
+             (.withClientConfiguration client-config)
+             (.build))))
+
 (defn endpoint-config []
   ;; TODO the endpoint should be set in env var
   (AwsClientBuilder$EndpointConfiguration. "http://localdocker:8083" "us-east-1"))
 
-(def stock-default-client
-  (delay (-> (AWSStepFunctionsClientBuilder/standard)
-             (.withClientConfiguration client-config)
-             (.withEndpointConfiguration (endpoint-config))
-             (.build))))
+(defn localhost-client []
+  (-> (AWSStepFunctionsClientBuilder/standard)
+      (.withClientConfiguration client-config)
+      (.withEndpointConfiguration (endpoint-config))
+      (.build)))
+
+(defn localhost-client? [^AWSStepFunctionsClient client]
+  ;; TODO get the client endpoint, I couldn't find a method for it yet
+  ;; though...
+  true
+  )
 
 (defn set-default-client! [^AWSStepFunctionsClient client]
   (reset! default-client client))

--- a/src/stepwise/client.clj
+++ b/src/stepwise/client.clj
@@ -4,6 +4,7 @@
   (:import (com.amazonaws.services.stepfunctions AWSStepFunctionsClient
                                                  AWSStepFunctionsClientBuilder)
            (com.amazonaws ClientConfiguration)
+           (com.amazonaws.client.builder AwsClientBuilder$EndpointConfiguration)
            (com.amazonaws.services.stepfunctions.builder StateMachine)))
 
 (set! *warn-on-reflection* true)
@@ -16,9 +17,14 @@
     (.setSocketTimeout 70000)
     (.setMaxConnections 75)))
 
+(defn endpoint-config []
+  ;; TODO the endpoint should be set in env var
+  (AwsClientBuilder$EndpointConfiguration. "http://localdocker:8083" "us-east-1"))
+
 (def stock-default-client
   (delay (-> (AWSStepFunctionsClientBuilder/standard)
              (.withClientConfiguration client-config)
+             (.withEndpointConfiguration (endpoint-config))
              (.build))))
 
 (defn set-default-client! [^AWSStepFunctionsClient client]

--- a/src/stepwise/client.clj
+++ b/src/stepwise/client.clj
@@ -171,6 +171,18 @@
         (.listStateMachines client)
         mdl/ListStateMachinesResult->map)))
 
+(defn get-state-machine-arn
+  "Lookup the state-machine from a SFN server and return the ARN"
+  ([name-ser]
+   (get-state-machine-arn (get-default-client) name-ser))
+  ([^AWSStepFunctionsClient client name-ser]
+   (->> (list-state-machines client {})
+        ;; should these namespaces be hardcoded or is there util fn?
+        (:stepwise.model/state-machines)
+        (filter #(= name-ser (:stepwise.model/name %)))
+        (first)
+        (:stepwise.model/arn))))
+
 (defn send-task-failure
   ([task-token]
    (send-task-failure task-token nil))

--- a/src/stepwise/iam.clj
+++ b/src/stepwise/iam.clj
@@ -1,6 +1,7 @@
 (ns stepwise.iam
   (:require [bean-dip.core :as bd]
             [clojure.data.json :as json]
+            [stepwise.client :as client]
             [stepwise.arns :as arns])
   (:import (com.amazonaws.services.identitymanagement AmazonIdentityManagementClientBuilder
                                                       AmazonIdentityManagement)
@@ -9,7 +10,8 @@
                                                             GetRoleRequest
                                                             GetRolePolicyRequest
                                                             NoSuchEntityException)
-           (com.amazonaws.regions DefaultAwsRegionProviderChain)))
+           (com.amazonaws.regions DefaultAwsRegionProviderChain)
+           (com.amazonaws AmazonWebServiceClient)))
 
 (def assume-role-policy
   {"Version"   "2012-10-17",
@@ -69,6 +71,11 @@
                                                              ::policy-document execution-policy}))))
       (arns/get-role-arn path role-name))))
 
-(defn ensure-execution-role []
-  @execution-role-arn)
+(defn ensure-execution-role
+  ([]
+   (ensure-execution-role nil))
+  ([^AmazonWebServiceClient client]
+   (if (and client (client/localhost-client? client))
+     "arn:aws:iam::123456789012:role/service-role/StepwiseStatesExecutionRole-localhost"
+     @execution-role-arn)))
 

--- a/test/stepwise/client_test.clj
+++ b/test/stepwise/client_test.clj
@@ -1,0 +1,7 @@
+(ns stepwise.client-test
+  (:require [clojure.test :refer :all]
+            [stepwise.client :as client]))
+
+(deftest localhost-client?-test
+  (is (false? (client/localhost-client? @client/stock-default-client)))
+  (is (true? (client/localhost-client? (client/localhost-client)))))

--- a/test/stepwise/core_test.clj
+++ b/test/stepwise/core_test.clj
@@ -1,0 +1,15 @@
+(ns stepwise.core-test
+  (:require [clojure.test :refer :all]
+            [stepwise.core :as sw]
+            [stepwise.client :as client]))
+
+(deftest ensure-state-machine-test
+  (is (= "arn:aws:states:us-east-1:123456789012:stateMachine:adder"
+         (sw/ensure-state-machine
+           (client/localhost-client)
+           :adder
+           {:start-at :add
+            :states   {:add {:type     :task
+                             :resource :activity/add
+                             :end      true}}}
+           {}))))


### PR DESCRIPTION
Part 1 changing `ensure-state-machine` to work with localhost SFN. Most of the work is cleaning up various aws-client calls (sfn, iam, sts) to respect endpoint configuration. I kept the `ensure-state-machine` signature the same but added some optional arities to pass in a client and/or parameters.